### PR TITLE
Fix BuildLink() for Coldbox 6 Compatibility.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 ## 4.1.0
+( SNAPSHOT CHANGES HERE )
+
+## 4.1.0
 
 ### Improvements
 

--- a/interceptors/GlobalData.cfc
+++ b/interceptors/GlobalData.cfc
@@ -20,7 +20,7 @@ component {
 			"expandAll" : prc.expandedResourceDivs,
 			"sessionEnabled" : getInstance( "APIService@relax" ).getSessionsEnabled(),
 			"url" : {
-				"moduleRoot" : replacenocase( event.buildLink( linkTo='relax', ssl=event.isSSL() ), "/index.cfm", "" ),
+				"moduleRoot" : replacenocase( event.buildLink( to='relax', ssl=event.isSSL() ), "/index.cfm", "" ),
 				"resourceDoc" : event.buildLink( prc.xehResourceDoc ),
 				"loadAPI" : event.buildLink( prc.xehLoadAPI ),
 				"exportHTML" : event.buildLink( prc.xehExportHTML ),

--- a/interceptors/GlobalData.cfc
+++ b/interceptors/GlobalData.cfc
@@ -20,7 +20,7 @@ component {
 			"expandAll" : prc.expandedResourceDivs,
 			"sessionEnabled" : getInstance( "APIService@relax" ).getSessionsEnabled(),
 			"url" : {
-				"moduleRoot" : replacenocase( event.buildLink( to='relax', ssl=event.isSSL() ), "/index.cfm", "" ),
+				"moduleRoot" : replacenocase( event.buildLink( 'relax' ), "/index.cfm", "" ),
 				"resourceDoc" : event.buildLink( prc.xehResourceDoc ),
 				"loadAPI" : event.buildLink( prc.xehLoadAPI ),
 				"exportHTML" : event.buildLink( prc.xehExportHTML ),


### PR DESCRIPTION
Coldbox 6 uses the argument `to` instead of `linkTo` when calling `buildLink()`